### PR TITLE
Create AUR package

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,5 +52,20 @@ brews:
       name: Will Chellman
       email: creaked@gmail.com
 
+aurs:
+  - homepage:  https://github.com/creaked/waitup
+    description: A utility to check when a system/service becomes available (RDP/SSH/Port)
+    maintainers:
+      - 'Will Chellman <creaked at gmail dot com>'
+      - 'Jonathan Neidel <aur at jneidel dot com>'
+    license: 'MIT'
+    private_key: '{{ .Env.AUR_KEY }}'
+    git_url: 'ssh://aur@aur.archlinux.org/waitup-bin.git'
+    package: |-
+      # bin
+      install -Dm755 "./waitup" "${pkgdir}/usr/bin/waitup"
+      # license
+      install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+
 checksum:
   name_template: 'checksums.txt' 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,14 @@ A utility to check when a system becomes available via SSH or RDP. Perfect for m
 
 ## Install
 
-### Using Homebrew (macOS/Linux)
+### Using Homebrew
 ```bash
 brew install creaked/tap/waitup
+```
+
+### AUR
+```bash
+yay -S waitup-bin
 ```
 
 ### Manual Installation


### PR DESCRIPTION
Hi @creaked,
I want to help you add an [aur](https://aur.archlinux.org/) package to your goreleaser setup if you are interested.

To get this setup please create an aur account, so I can add you as a maintainer there. (The answer to the spam protection is `5f2868`)

- [ ] aur account created and set as comaintainer
- [x] placeholder pkg repo created
- [x] Does this package have autocompletions or a manpage? (if so we would add them here)

With the first release you do after this is merged I will check that everything works properly.