### PR TITLE
Add --quiet and --timeout flags for automation and scripting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A utility to check when a system becomes available via SSH or RDP. Perfect for m
 - RDP support for Windows (mstsc), macOS (Microsoft Remote Desktop), and Linux (xfreerdp/rdesktop)
 - Progress indicator while waiting
 - Connection statistics (time elapsed, attempts)
+- Quiet mode for automation and scripting (suppresses output, returns exit codes)
+- Timeout support to prevent indefinite waiting
 
 ## Install
 
@@ -42,8 +44,10 @@ go build
 ```
 
 ## Usage
+
+### Basic Usage
 ```console
-# Basic usage
+# Monitor a host (default: SSH/RDP ports)
 waitup hostname
 
 # Examples
@@ -51,18 +55,55 @@ waitup server1.example.com
 waitup 192.168.1.100
 
 # Monitor specific port
-waitup server1 -p 8080
-waitup 10.0.0.1 -p 443
+waitup -p 8080 server1
+waitup -p 443 10.0.0.1
 ```
+
+### Automation & Scripting
+Perfect for CI/CD pipelines and automation scripts:
+
+```console
+# Quiet mode - suppresses output, only returns exit code
+waitup -q server1.example.com
+waitup --quiet 192.168.1.100
+
+# With timeout - prevents indefinite waiting
+waitup -t 30s server1.example.com      # Wait up to 30 seconds
+waitup --timeout 5m 192.168.1.100      # Wait up to 5 minutes
+
+# Combined for scripting
+waitup -q -t 2m -p 8080 server1        # Quiet mode with 2-minute timeout
+
+# Use in scripts
+if waitup -q -t 30s myserver.com; then
+    echo "Server is ready!"
+    # Deploy or connect
+else
+    echo "Server did not come up in time"
+    exit 1
+fi
+```
+
+### Options
+- `-p, --port PORT` - Monitor a specific port
+- `-q, --quiet` - Suppress output (useful for scripts)
+- `-t, --timeout DURATION` - Maximum wait time (e.g., 30s, 5m, 1h)
+- `-h, --help` - Show help message
+- `-v, --version` - Show version information
+
+### Exit Codes
+- `0` - Connection established successfully
+- `1` - Timeout reached or error occurred
+
+### Behavior
 The tool will continuously check the specified port(s) until one becomes available:
 - By default, checks SSH (22) and RDP (3389)
-- Use -p flag to monitor a specific port
+- Use `-p` flag to monitor a specific port
+- Progress is shown with dots (unless `--quiet` is used)
 
-When a connection is established:
+When a connection is established (in interactive mode):
 - For SSH: Prompts to connect using your system's SSH client
 - For RDP: Launches your system's default RDP client
-
-Progress is shown with dots, and you'll get a notification when the system is ready.
 
 ## Requirements
 - For SSH connections: SSH client installed


### PR DESCRIPTION
This commit adds two new flags to make waitup more flexible for use in automation scripts, CI/CD pipelines, and other non-interactive scenarios:

--quiet/-q flag:
  - Suppresses all normal output
  - Only returns exit codes (0 for success, 1 for timeout/failure)
  - Skips interactive prompts for SSH/RDP connections
  - Perfect for use in shell scripts and automation

--timeout/-t flag:
  - Sets maximum wait time before giving up
  - Accepts duration format: 30s, 5m, 1h, 90m, etc.
  - Also accepts bare numbers which default to seconds: -t 30
  - Prevents indefinite hangs if host never becomes available
  - Returns exit code 1 when timeout is reached

Additional improvements:
  - Refactored to use Go's flag package for proper argument parsing
  - Flexible argument ordering - hostname can be placed anywhere
  - Supports both short and long flag formats (-q/--quiet, -t/--timeout)
  - Fixed IPv6 compatibility using net.JoinHostPort
  - Improved help text with comprehensive examples
  - Better error messages and validation

Updated README with:
  - New automation & scripting section with examples
  - Documentation of exit codes
  - Usage examples for CI/CD pipelines
  - Shell script integration examples

Examples:
  waitup -q -t 30s server.com
  waitup server.com -p 8080 -t 5m --quiet
  if waitup -q -t 2m myapp.com; then deploy; fi